### PR TITLE
fix: Supplement the 'peerDependencies' field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "test": "node test/index.mjs",
     "prepublishOnly": "npm run build"
   },
+  "peerDependencies": {
+    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+  },
   "dependencies": {
     "lib-esm": "~0.3.0"
   },


### PR DESCRIPTION
A package should have a 'peerDependencies' field if it needs to rely on other packages that are not in the' dependencies' package to function properly